### PR TITLE
Use HTTPS

### DIFF
--- a/betarelease-repo.xml
+++ b/betarelease-repo.xml
@@ -11,7 +11,7 @@
 			<desc  lang="EN">BBCiPlayer Extra which provides access to many iPlayer radio programs by title and latest in categories.</desc>
 			<creator>bpa</creator>
 			<email>baltontwo@eircom.net</email>
-			<url>http://downloads.sourceforge.net/project/bpaplugins/BBCiPlayerExtra-v301_0.ZIP</url>
+			<url>https://downloads.sourceforge.net/project/bpaplugins/BBCiPlayerExtra-v301_0.ZIP</url>
 			<sha>270fe48736c2098df13bc2c1a42a9da53c5d0162</sha>
 		</plugin>
 		<plugin name="BBCiPlayer" version="1.6.7" minTarget="7.7" maxTarget="*">
@@ -19,7 +19,7 @@
 			<desc  lang="EN">Listen to BBC iPlayer Live and Listen Again Radio streams.  Supports the highest quality streams available from the BBC for your location.  Users outside the UK are now able to receive restricted bitrate versions of all of the content available to UK users.  This includes listen again recordings of the last 7 days of BBC National, Regional and Local Radio from the UK.  DASH support added by bpa</desc>
 			<creator>bpa</creator>
 			<email>baltontwo@eircom.com</email>
-			<url>http://downloads.sourceforge.net/project/bpaplugins/BBCiPlayer-V1_6_7.ZIP</url>
+			<url>https://downloads.sourceforge.net/project/bpaplugins/BBCiPlayer-V1_6_7.ZIP</url>
 			<sha>394123df2922e1cd962bdacecb75904e89a77860</sha>
 		</plugin>
 	</plugins>


### PR DESCRIPTION
These HTTP URLs aren't usable by anyone who lacks SSL support, since they redirect to HTTPS URLs.  We may as well start with the secure versions.